### PR TITLE
Implement correct reference reader

### DIFF
--- a/plugins/git/git_shard_info.go
+++ b/plugins/git/git_shard_info.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chrislusf/gleam/util"
 	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 type shardInfo struct {
@@ -84,19 +83,6 @@ func (s *shardInfo) ReadSplit() error {
 		if _, err := reader.ReadHeader(); err != nil {
 			return errors.Wrap(err, "could not read headers")
 		}
-	}
-
-	if s.DataType == "references" {
-		refs, err := repo.References()
-		if err != nil {
-			return errors.Wrap(err, "could not read references")
-		}
-		return refs.ForEach(func(ref *plumbing.Reference) error {
-			if ref.Hash().IsZero() {
-				return nil
-			}
-			return getRefChildren(s.RepoPath, ref.Hash().String(), ref.Name().String())
-		})
 	}
 
 	for {

--- a/plugins/git/references/references_git_reader.go
+++ b/plugins/git/references/references_git_reader.go
@@ -1,12 +1,14 @@
 package references
 
 import (
+	"io"
 	"strconv"
 
 	"github.com/chrislusf/gleam/util"
 	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	storer "gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
@@ -14,6 +16,11 @@ type Reader struct {
 	repositoryID string
 	repo         *git.Repository
 	refs         storer.ReferenceIter
+	commitsIter  object.CommitIter
+
+	refCommitHash string
+	refName       string
+	refIsRemote   string
 }
 
 func NewReader(repo *git.Repository, path string) (*Reader, error) {
@@ -39,33 +46,52 @@ func (r *Reader) ReadHeader() ([]string, error) {
 }
 
 func (r *Reader) Read() (*util.Row, error) {
-	ref, err := r.refs.Next()
+	if r.commitsIter == nil {
+		ref, err := r.refs.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		// Get correct commit hash
+		// there is Repository.ResolveRevision but it fails on some tags and performance is worst
+		refCommitHash := ref.Hash()
+		// handle symbolic references like HEAD
+		if ref.Type() == plumbing.SymbolicReference {
+			targetRef, _ := r.repo.Reference(ref.Target(), true)
+			refCommitHash = targetRef.Hash()
+		}
+
+		// handle tag references
+		tag, err := r.repo.TagObject(refCommitHash)
+		if err == nil {
+			commit, _ := tag.Commit()
+			refCommitHash = commit.Hash
+		}
+
+		r.commitsIter, err = r.repo.Log(&git.LogOptions{From: refCommitHash})
+		if err != nil {
+			return nil, err
+		}
+
+		r.refCommitHash = refCommitHash.String()
+		r.refName = ref.Name().String()
+		r.refIsRemote = strconv.FormatBool(ref.Name().IsRemote())
+	}
+
+	commit, err := r.commitsIter.Next()
+	if err == io.EOF {
+		r.commitsIter = nil
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	// Get correct commit hash
-	// there is Repository.ResolveRevision but it fails on some tags and performance is worst
-
-	commitHash := ref.Hash()
-	// handle symbolic references like HEAD
-	if ref.Type() == plumbing.SymbolicReference {
-		targetRef, _ := r.repo.Reference(ref.Target(), true)
-		commitHash = targetRef.Hash()
-	}
-
-	// handle tag references
-	tag, err := r.repo.TagObject(commitHash)
-	if err == nil {
-		commit, _ := tag.Commit()
-		commitHash = commit.Hash
-	}
-
 	return util.NewRow(util.Now(),
 		r.repositoryID,
-		ref.Hash().String(),
-		ref.Name().String(),
-		commitHash.String(),
-		strconv.FormatBool(ref.Name().IsRemote()),
+		r.refCommitHash,
+		r.refName,
+		commit.Hash.String(),
+		r.refIsRemote,
 	), nil
 }

--- a/plugins/git/references/references_git_reader.go
+++ b/plugins/git/references/references_git_reader.go
@@ -1,14 +1,18 @@
 package references
 
 import (
+	"strconv"
+
 	"github.com/chrislusf/gleam/util"
 	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	storer "gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
 type Reader struct {
 	repositoryID string
+	repo         *git.Repository
 	refs         storer.ReferenceIter
 }
 
@@ -19,6 +23,7 @@ func NewReader(repo *git.Repository, path string) (*Reader, error) {
 	}
 	return &Reader{
 		repositoryID: path,
+		repo:         repo,
 		refs:         refs,
 	}, nil
 }
@@ -29,15 +34,38 @@ func (r *Reader) ReadHeader() ([]string, error) {
 		"refHash",
 		"refName",
 		"commitHash",
+		"isRemote",
 	}, nil
 }
 
-//TODO: add is_remote
 func (r *Reader) Read() (*util.Row, error) {
 	ref, err := r.refs.Next()
 	if err != nil {
 		return nil, err
 	}
 
-	return util.NewRow(util.Now(), r.repositoryID, ref.Hash().String(), ref.Name().String()), nil
+	// Get correct commit hash
+	// there is Repository.ResolveRevision but it fails on some tags and performance is worst
+
+	commitHash := ref.Hash()
+	// handle symbolic references like HEAD
+	if ref.Type() == plumbing.SymbolicReference {
+		targetRef, _ := r.repo.Reference(ref.Target(), true)
+		commitHash = targetRef.Hash()
+	}
+
+	// handle tag references
+	tag, err := r.repo.TagObject(commitHash)
+	if err == nil {
+		commit, _ := tag.Commit()
+		commitHash = commit.Hash
+	}
+
+	return util.NewRow(util.Now(),
+		r.repositoryID,
+		ref.Hash().String(),
+		ref.Name().String(),
+		commitHash.String(),
+		strconv.FormatBool(ref.Name().IsRemote()),
+	), nil
 }

--- a/plugins/git/references/references_git_reader.go
+++ b/plugins/git/references/references_git_reader.go
@@ -81,7 +81,7 @@ func (r *Reader) Read() (*util.Row, error) {
 	commit, err := r.commitsIter.Next()
 	if err == io.EOF {
 		r.commitsIter = nil
-		return nil, nil
+		return r.Read()
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I didn't really get why you changed get references reader using `git` instead of `go-git`.
Anyway, I didn't touch that if statement, just corrected reader itself.

* Return commit hash

Engine hides real reference hash and always returns commit hash, but here I return both of them.

Resolving correct commit hash is a bit tricky with go git.
Reference can be symbolic and it can be a tag.
I handle both cases and validated results using engine.

* Add isRemote flag

Validation output:
Engine: https://gist.github.com/smacker/4af884632182a38e7fe886a018c6e76a
This PR (without `if` for references in`shardInfo`): https://gist.github.com/smacker/c2df9045a058d54af01a6c92935d465b

I don't remove `remotes` prefix from a name, but we can do it later if we need.

Thanks!